### PR TITLE
[FEAT] 작품 태그 인식 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,8 @@ dependencies {
 	testImplementation 'org.springframework.security:spring-security-test'
 	implementation('org.springframework.boot:spring-boot-starter-oauth2-client')
 	implementation('com.auth0:java-jwt:4.4.0')		//jwt 오픈소스 라이브러리 java-jwt
+	implementation group: 'org.apache.commons', name: 'commons-text', version: '1.9' // 작품명 유사도 검증 라이브러리
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/eight/artwork/controller/ArtworkController.java
+++ b/src/main/java/com/example/eight/artwork/controller/ArtworkController.java
@@ -1,8 +1,6 @@
 package com.example.eight.artwork.controller;
 
-import com.example.eight.artwork.dto.DetectionRequestDto;
-import com.example.eight.artwork.dto.DetectionResponseDto;
-import com.example.eight.artwork.dto.PartsResponseDto;
+import com.example.eight.artwork.dto.*;
 import com.example.eight.artwork.service.ArtworkService;
 import lombok.AllArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -34,6 +32,18 @@ public class ArtworkController{
     public ResponseEntity<PartsResponseDto> getArtworkParts(@RequestParam Long id) {
         PartsResponseDto responseDto = artworkService.getArtworkParts(id);
         return ResponseEntity.ok(responseDto);
+    }
+
+    // 태그 인식
+    @PostMapping("/recognize-tag")
+    public ResponseEntity<TagResponseDto> recognizeTag(@RequestBody TagRequestDto requestDto) {
+        TagResponseDto tagResponseDto = artworkService.performTagRecognition(requestDto);
+
+        if (tagResponseDto != null) {
+            return ResponseEntity.ok(tagResponseDto);
+        } else {
+            return ResponseEntity.badRequest().build();
+        }
     }
 
 }

--- a/src/main/java/com/example/eight/artwork/dto/TagRequestDto.java
+++ b/src/main/java/com/example/eight/artwork/dto/TagRequestDto.java
@@ -1,0 +1,14 @@
+package com.example.eight.artwork.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class TagRequestDto {
+    private String text;
+}

--- a/src/main/java/com/example/eight/artwork/dto/TagResponseDto.java
+++ b/src/main/java/com/example/eight/artwork/dto/TagResponseDto.java
@@ -1,0 +1,20 @@
+package com.example.eight.artwork.dto;
+
+import lombok.*;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class TagResponseDto {
+    private Long id;
+    private String name;
+
+    public static class TagResponseDtoBuilder {
+
+        public TagResponseDtoBuilder id(Long id) {
+            this.id = id;
+            return this;
+        }
+    }
+}

--- a/src/main/java/com/example/eight/artwork/repository/RelicRepository.java
+++ b/src/main/java/com/example/eight/artwork/repository/RelicRepository.java
@@ -9,7 +9,7 @@ import java.util.List;
 
 @Repository
 public interface RelicRepository extends JpaRepository<Relic, Long> {
-
+    Relic findByName(String name);
     @Override
     <S extends Relic> S save(S entity);
 }

--- a/src/main/java/com/example/eight/artwork/service/ArtworkService.java
+++ b/src/main/java/com/example/eight/artwork/service/ArtworkService.java
@@ -169,6 +169,27 @@ public class ArtworkService {
         return artworkNames;
     }
 
+    // 유사한 작품명 찾기
+    // Jaro-Winkler 유사도 계산
+    private String findBestMatchingName(String detectedTag, List<String> artworkNames) {
+        String bestMatchingName = null;
+        double maxSimilarity = 0.0;
+
+        JaroWinklerDistance jaroWinklerDistance = new JaroWinklerDistance();
+
+        for (String name : artworkNames) {
+            // 유사도 계산
+            double similarity = jaroWinklerDistance.apply(detectedTag, name);
+            if (similarity > maxSimilarity) {
+                // 더 큰 유사도를 찾았을 경우 값을 업데이트하고 작품명 저장
+                maxSimilarity = similarity;
+                bestMatchingName = name;
+            }
+        }
+
+        return bestMatchingName;  // 가장 유사한 작품명 반환
+    }
+
 }
 
 

--- a/src/main/java/com/example/eight/artwork/service/ArtworkService.java
+++ b/src/main/java/com/example/eight/artwork/service/ArtworkService.java
@@ -1,9 +1,6 @@
 package com.example.eight.artwork.service;
 
-import com.example.eight.artwork.dto.DetectionRequestDto;
-import com.example.eight.artwork.dto.DetectionResponseDto;
-import com.example.eight.artwork.dto.PartInfoDto;
-import com.example.eight.artwork.dto.PartsResponseDto;
+import com.example.eight.artwork.dto.*;
 import com.example.eight.artwork.entity.Element;
 import com.example.eight.artwork.entity.Part;
 import com.example.eight.artwork.entity.Relic;
@@ -11,6 +8,7 @@ import com.example.eight.artwork.entity.SolvedElement;
 import com.example.eight.artwork.repository.*;
 
 import lombok.RequiredArgsConstructor;
+import org.apache.commons.text.similarity.JaroWinklerDistance;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -112,6 +110,29 @@ public class ArtworkService {
 
         return responseDto;  // 최종 응답 객체
     }
+
+    // 태그 인식 API
+    public TagResponseDto performTagRecognition(TagRequestDto requestDto) {
+        String detectedTag = requestDto.getText();
+
+        // 데이터베이스에서 태그와 일치하는 작품 정보 조회
+        Relic relic = relicRepository.findByName(detectedTag);
+
+        // 응답 객체 생성 전 relicId 변수 초기화
+        Long relicId;
+        String bestMatchingName = null;
+
+        // 응답 객체 생성
+        if (relicId != null) {
+            return TagResponseDto.builder()
+                    .id(relicId)
+                    .name(bestMatchingName)  // 유사한 작품명 사용
+                    .build();
+        } else {
+            return null;  // 유사한 작품명을 찾지 못한 경우
+        }
+    }
+
 
 }
 

--- a/src/main/java/com/example/eight/artwork/service/ArtworkService.java
+++ b/src/main/java/com/example/eight/artwork/service/ArtworkService.java
@@ -42,6 +42,7 @@ public class ArtworkService {
             return null;
         }
     }
+
     private Element validateAndRecordElement(DetectionRequestDto requestDto) {
         String elementName = requestDto.getName();
         Element element = elementRepository.findByName(elementName);
@@ -127,6 +128,23 @@ public class ArtworkService {
             // ID 설정
             relicId = relic.getId();
             bestMatchingName = detectedTag;
+        } else {
+            // 데이터베이스에 태그와 일치하는 작품명이 없을 때, 유사한 작품명 찾기
+            List<String> allArtworkNames = getAllArtworkNames();
+            bestMatchingName = findBestMatchingName(detectedTag, allArtworkNames);
+
+            if (bestMatchingName != null) {
+                // ID 설정
+                relic = relicRepository.findByName(bestMatchingName);
+                if (relic != null) {
+                    relicId = relic.getId();
+                } else {
+                    relicId = null;
+                }
+            } else {
+                // 유사한 작품명도 없을 경우
+                relicId = null;
+            }
         }
 
         // 응답 객체 생성
@@ -139,9 +157,4 @@ public class ArtworkService {
             return null;  // 유사한 작품명을 찾지 못한 경우
         }
     }
-
-
 }
-
-
-

--- a/src/main/java/com/example/eight/artwork/service/ArtworkService.java
+++ b/src/main/java/com/example/eight/artwork/service/ArtworkService.java
@@ -42,7 +42,6 @@ public class ArtworkService {
             return null;
         }
     }
-
     private Element validateAndRecordElement(DetectionRequestDto requestDto) {
         String elementName = requestDto.getName();
         Element element = elementRepository.findByName(elementName);
@@ -157,4 +156,20 @@ public class ArtworkService {
             return null;  // 유사한 작품명을 찾지 못한 경우
         }
     }
+
+    // 모든 작품명 가져오기
+    private List<String> getAllArtworkNames() {
+        List<Relic> relics = relicRepository.findAll();
+        List<String> artworkNames = new ArrayList<>();
+
+        for (Relic relic : relics) {
+            artworkNames.add(relic.getName());
+        }
+
+        return artworkNames;
+    }
+
 }
+
+
+

--- a/src/main/java/com/example/eight/artwork/service/ArtworkService.java
+++ b/src/main/java/com/example/eight/artwork/service/ArtworkService.java
@@ -122,6 +122,13 @@ public class ArtworkService {
         Long relicId;
         String bestMatchingName = null;
 
+        // 데이터베이스에 태그와 일치하는 작품명이 있는 경우
+        if (relic != null) {
+            // ID 설정
+            relicId = relic.getId();
+            bestMatchingName = detectedTag;
+        }
+
         // 응답 객체 생성
         if (relicId != null) {
             return TagResponseDto.builder()
@@ -135,7 +142,6 @@ public class ArtworkService {
 
 
 }
-
 
 
 


### PR DESCRIPTION
## 이슈 번호 :round_pushpin:
#12 

## 작업 내용 :technologist:
- 클라이언트로부터 받은 태그 인식 결과를 기반으로 DB에서 작품 정보를 조회하는 API를 구현하였습니다.
- 일치하는 작품명이 있을 경우 해당 작품명을 응답으로 반환합니다.
- 일치하는 작품명이 없는 경우 JaroWinklerDistanc 라이브러리를 통해 유사도 측정을 합니다. 유사한 작품명을 찾아 응답으로 반환하도록 구현했습니다.

## 반영 브랜치 :rocket:
ex) artwork/yeni -> main

## To Reviewers :speech_balloon:
- API 테스트까지 진행 완료했습니다.