### PR TITLE
[FEAT] 유저 프로필 조회 API 구현

### DIFF
--- a/src/main/java/com/example/eight/user/controller/UserController.java
+++ b/src/main/java/com/example/eight/user/controller/UserController.java
@@ -1,10 +1,14 @@
 package com.example.eight.user.controller;
 
+import com.example.eight.user.dto.ResponseDto;
+import com.example.eight.user.dto.UserProfileDto;
+import com.example.eight.user.service.UserService;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.io.IOException;
@@ -19,6 +23,7 @@ public class UserController {
     @Value("${spring.security.oauth2.client.registration.google.client-id}")
     private String googleClientId;
 
+    private final UserService userService;
 
 
     @GetMapping("/")
@@ -56,4 +61,18 @@ public class UserController {
         response.sendRedirect(GoogleLoginURI);
     }
 
+    // 유저 프로필 조회
+    @GetMapping("/app/users/profile")
+    public ResponseEntity<ResponseDto> getUserInfo() {
+        // 프로필 응답 생성
+        UserProfileDto userProfileDto = userService.getUserProfile();
+
+        ResponseDto responseDto = ResponseDto.builder()
+                .status("success")
+                .message("Get user profile successful")
+                .data(userProfileDto)
+                .build();
+
+        return ResponseEntity.ok(responseDto);
+    }
 }

--- a/src/main/java/com/example/eight/user/dto/UserProfileDto.java
+++ b/src/main/java/com/example/eight/user/dto/UserProfileDto.java
@@ -1,0 +1,40 @@
+package com.example.eight.user.dto;
+
+import com.example.eight.user.Role;
+import com.example.eight.user.SocialType;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+public class UserProfileDto {
+    private Long id;
+    private String name;
+    private String email;
+    private String picture;
+    private double exp;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+    private Role role;
+    private SocialType socialType;
+
+
+    @Builder
+    public UserProfileDto(Long id, String name, String email, double exp, String picture,
+                          LocalDateTime createdAt, LocalDateTime updatedAt,
+                          Role role, SocialType socialType){
+        this.id = id;
+        this.name = name;
+        this.email = email;
+        this.picture = picture;
+        this.exp = exp;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+        this.role = role;
+        this.socialType = socialType;
+    }
+
+}

--- a/src/main/java/com/example/eight/user/service/UserService.java
+++ b/src/main/java/com/example/eight/user/service/UserService.java
@@ -1,5 +1,6 @@
 package com.example.eight.user.service;
 
+import com.example.eight.user.dto.UserProfileDto;
 import com.example.eight.user.entity.User;
 import com.example.eight.user.repository.UserRepository;
 import lombok.extern.slf4j.Slf4j;
@@ -40,5 +41,22 @@ public class UserService {
             user.updateRefreshToken(refreshToken);
             userRepository.save(user); // 변경 사항을 데이터베이스에 저장
         }
+    }
+
+    public UserProfileDto getUserProfile() {
+
+        User user = getAuthentication();    // 현재 로그인한 유저 정보
+
+        return UserProfileDto.builder()
+                .id(user.getId())
+                .name(user.getName())
+                .email(user.getEmail())
+                .picture(user.getPicture())
+                .exp(user.getExp())
+                .createdAt(user.getCreatedAt())
+                .updatedAt(user.getUpdatedAt())
+                .role(user.getRole())
+                .socialType(user.getSocialType())
+                .build();
     }
 }

--- a/src/main/java/com/example/eight/user/service/UserService.java
+++ b/src/main/java/com/example/eight/user/service/UserService.java
@@ -4,19 +4,32 @@ import com.example.eight.user.entity.User;
 import com.example.eight.user.repository.UserRepository;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
-//@Transactional
 @Service
 public class UserService {
-    //추가
     private final UserRepository userRepository;
 
     @Autowired
     public UserService(UserRepository userRepository){
         this.userRepository = userRepository;
+    }
+
+    // 현재 로그인한 Authentication 가져오기
+    public User getAuthentication(){
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        UserDetails principal = (UserDetails) authentication.getPrincipal();
+        String userEmail = principal.getUsername();
+
+        log.info("Authentication에서 가져온 유저 이메일: {}", userEmail);
+
+        // 로그인한 User 객체 반환
+        return userRepository.findByEmail(userEmail).orElse(null);
     }
 
     @Transactional


### PR DESCRIPTION
## 이슈 번호 :round_pushpin:
#15 

## 작업 내용 :technologist:
- 유저 프로필 정보를 조회하는 API입니다. 
- 로그인한 유저의 Authentication을 가져오는 getAuthentication() 메소드를 추가하였습니다. 
- 서비스 클래스에 getUserProfile() 메소드를 추가하였고, DTO 클래스를 사용하여 Response를 생성했습니다.

## 반영 브랜치 :rocket:
login/jina -> main

## To Reviewers :speech_balloon:
- API 테스트 완료했습니다. 
- 로그인한 유저 정보는 추후 @LoginUser 애노테이션을 이용하는 방식으로 변경할 예정입니다.
