### PR TITLE
[FEAT] 작품 부분 정보 조회 API에 공공 API 불러오기 추가

### DIFF
--- a/src/main/java/com/example/eight/artwork/controller/ArtworkController.java
+++ b/src/main/java/com/example/eight/artwork/controller/ArtworkController.java
@@ -28,9 +28,9 @@ public class ArtworkController{
     }
 
     // 작품 부분 정보 조회 (퍼즐 페이지)
-    @GetMapping("/partsinfo")
-    public ResponseEntity<PartsResponseDto> getArtworkParts(@RequestParam Long id) {
-        PartsResponseDto responseDto = artworkService.getArtworkParts(id);
+    @GetMapping("/partsinfo/{relic_id}")
+    public ResponseEntity<PartsResponseDto> getArtworkParts(@PathVariable("relic_id") Long relicId) {
+        PartsResponseDto responseDto = artworkService.getArtworkParts(relicId); // relicId를 전달
         return ResponseEntity.ok(responseDto);
     }
 

--- a/src/main/java/com/example/eight/artwork/entity/Relic.java
+++ b/src/main/java/com/example/eight/artwork/entity/Relic.java
@@ -20,7 +20,7 @@ public class Relic {
     private Long id;
 
     @Column(name = "api_id")
-    private Long apiId;
+    private String apiId;
 
     @NotNull
     @Column(name = "name", length = 30)
@@ -45,7 +45,7 @@ public class Relic {
     private List<Part> parts = new ArrayList<>();
 
     @Builder
-    public Relic(Long apiId, @NotNull String name, @NotNull String image, @NotNull String badgeImage,
+    public Relic(String apiId, @NotNull String name, @NotNull String image, @NotNull String badgeImage,
                  String location, @NotNull Integer partNum, List<Part> parts) {
         this.apiId = apiId;
         this.name = name;

--- a/src/main/java/com/example/eight/artwork/repository/RelicRepository.java
+++ b/src/main/java/com/example/eight/artwork/repository/RelicRepository.java
@@ -1,15 +1,18 @@
 package com.example.eight.artwork.repository;
 
-import com.example.eight.artwork.entity.Part;
 import com.example.eight.artwork.entity.Relic;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
+import java.util.Optional;
 
 import java.util.List;
 
 @Repository
 public interface RelicRepository extends JpaRepository<Relic, Long> {
     Relic findByName(String name);
+
+    Optional<Relic> findByApiId(String apiId);
+
     @Override
     <S extends Relic> S save(S entity);
 }

--- a/src/main/java/com/example/eight/artwork/service/ArtworkService.java
+++ b/src/main/java/com/example/eight/artwork/service/ArtworkService.java
@@ -152,7 +152,19 @@ public class ArtworkService {
                     String artworkImageUrl = firstItem.get("imgUri").asText();
 
                     return artworkImageUrl;
+                } else {
+                    // API 응답에서 이미지 URI를 찾을 수 없는 경우
+                    return "Artwork image not found in API response.";
                 }
+            } catch (Exception e) {
+                // 예외 처리
+                e.printStackTrace();
+                return "Error occurred while fetching image URI: " + e.getMessage();
+            }
+        } else {
+            // 작품이 발견되지 않았을 때
+            return "Relic not found for ID: " + relicId;
+        }
     }
 
     // 태그 인식 API

--- a/src/main/java/com/example/eight/artwork/service/ArtworkService.java
+++ b/src/main/java/com/example/eight/artwork/service/ArtworkService.java
@@ -7,15 +7,26 @@ import com.example.eight.artwork.entity.Relic;
 import com.example.eight.artwork.entity.SolvedElement;
 import com.example.eight.artwork.repository.*;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nimbusds.jose.shaded.gson.Gson;
+import com.nimbusds.jose.shaded.gson.JsonElement;
+import com.nimbusds.jose.shaded.gson.JsonObject;
+import com.nimbusds.jose.shaded.gson.JsonParser;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.text.similarity.JaroWinklerDistance;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestTemplate;
 
+import java.net.URI;
+import java.net.URLEncoder;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
 
 @Service
 @Transactional
@@ -64,7 +75,6 @@ public class ArtworkService {
 
     // 작품 소제목 조회 API
     public PartsResponseDto getArtworkParts(Long relicId) {
-
         // TODO: 현재 로그인된 사용자 정보 가져오는 로직 추가 필요
         // User currentUser = getCurrentUser();
 
@@ -75,6 +85,9 @@ public class ArtworkService {
         }
 
         Relic relic = optionalRelic.get();
+
+        // 작품 이미지 URI 가져오기
+        String relicImageUri = getRelicImageUri(relicId);
 
         // 부분 정보 조회 및 변환
         List<Part> parts = partRepository.findByRelic(relic);
@@ -101,7 +114,7 @@ public class ArtworkService {
 
         PartsResponseDto responseDto = PartsResponseDto.builder()
                 .relicName(relic.getName())
-                .relicImage(relic.getImage())
+                .relicImage(relicImageUri)  // 작품 이미지 URI 설정
                 .relicBadgeImage(relic.getBadgeImage())
                 .partInfos(partInfoDtos)
                 .totalPartCount(parts.size())
@@ -110,6 +123,7 @@ public class ArtworkService {
 
         return responseDto;  // 최종 응답 객체
     }
+
 
     // 태그 인식 API
     public TagResponseDto performTagRecognition(TagRequestDto requestDto) {

--- a/src/main/java/com/example/eight/artwork/service/ArtworkService.java
+++ b/src/main/java/com/example/eight/artwork/service/ArtworkService.java
@@ -124,6 +124,25 @@ public class ArtworkService {
         return responseDto;  // 최종 응답 객체
     }
 
+    // 작품 이미지 URI 가져오는 메서드
+    public String getRelicImageUri(Long relicId) {
+        // 작품 id로 작품 찾기
+        Optional<Relic> relicOptional = relicRepository.findById(relicId);
+
+        if (relicOptional.isPresent()) {
+            Relic relic = relicOptional.get();
+
+            try {
+                String serviceKey = "Enter the service key";
+
+                // API 요청 URL 생성
+                String apiUrl = "http://www.emuseum.go.kr/openapi/relic/detail?serviceKey=" + URLEncoder.encode(serviceKey, "UTF-8") + "&id=" + relic.getApiId();
+
+                URI uri = new URI(apiUrl);
+                RestTemplate restTemplate = new RestTemplate();
+                String apiResponse = restTemplate.getForObject(uri, String.class);
+
+    }
 
     // 태그 인식 API
     public TagResponseDto performTagRecognition(TagRequestDto requestDto) {

--- a/src/main/java/com/example/eight/artwork/service/ArtworkService.java
+++ b/src/main/java/com/example/eight/artwork/service/ArtworkService.java
@@ -133,7 +133,7 @@ public class ArtworkService {
             Relic relic = relicOptional.get();
 
             try {
-                String serviceKey = "Enter the service key";
+                String serviceKey = "enter the service key";
 
                 // API 요청 URL 생성
                 String apiUrl = "http://www.emuseum.go.kr/openapi/relic/detail?serviceKey=" + URLEncoder.encode(serviceKey, "UTF-8") + "&id=" + relic.getApiId();
@@ -142,6 +142,17 @@ public class ArtworkService {
                 RestTemplate restTemplate = new RestTemplate();
                 String apiResponse = restTemplate.getForObject(uri, String.class);
 
+                // API 응답 파싱하여 이미지 uri 가져오기
+                ObjectMapper objectMapper = new ObjectMapper();
+                JsonNode jsonNode = objectMapper.readTree(apiResponse);
+                JsonNode listNode = jsonNode.get("list");
+
+                if (listNode != null && listNode.isArray() && listNode.size() > 0) {
+                    JsonNode firstItem = listNode.get(0);
+                    String artworkImageUrl = firstItem.get("imgUri").asText();
+
+                    return artworkImageUrl;
+                }
     }
 
     // 태그 인식 API

--- a/src/main/java/com/example/eight/config/RestTemplateConfig.java
+++ b/src/main/java/com/example/eight/config/RestTemplateConfig.java
@@ -1,0 +1,14 @@
+package com.example.eight.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestTemplateConfig {
+
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+}


### PR DESCRIPTION
## 이슈 번호 :round_pushpin:
#8 

## 작업 내용 :technologist:
- 작품 부분 정보 조회 API 응답 중 이미지 정보를 공공 API를 통해 불러오도록 구현했습니다.

## 반영 브랜치 :rocket:
ex) artwork/yeni -> main

## To Reviewers :speech_balloon:
- 공공 API 이용을 위해 필요한 서비스 키는 노션>문서>환경변수 파일에서 확인해주세요!
