### PR TITLE
[FEAT] 부분의 각 요소 조회 API 추가 

### DIFF
--- a/src/main/java/com/example/eight/artwork/controller/ArtworkController.java
+++ b/src/main/java/com/example/eight/artwork/controller/ArtworkController.java
@@ -1,5 +1,6 @@
 package com.example.eight.artwork.controller;
 
+import com.example.eight.user.dto.ResponseDto;
 import com.example.eight.artwork.dto.*;
 import com.example.eight.artwork.service.ArtworkService;
 import lombok.AllArgsConstructor;
@@ -34,6 +35,21 @@ public class ArtworkController{
         return ResponseEntity.ok(responseDto);
     }
 
+    // 부분에 속하는 요소 리스트 & 수집여부 조회
+    @GetMapping("/elements")
+    public ResponseEntity<ResponseDto> getArtworkElements(@RequestParam Long relicId, @RequestParam Long partId){
+        // 각 요소 정보 및 수집여부 응답 생성
+        ElementResponseDto elementResponseDto = artworkService.getElementDetail(relicId, partId);
+
+        ResponseDto responseDto = ResponseDto.builder()
+                .status("success")
+                .message("Get detail for each element of part successful")
+                .data(elementResponseDto)
+                .build();
+
+        return ResponseEntity.ok(responseDto);
+    }
+
     // 태그 인식
     @PostMapping("/recognize-tag")
     public ResponseEntity<TagResponseDto> recognizeTag(@RequestBody TagRequestDto requestDto) {
@@ -45,5 +61,7 @@ public class ArtworkController{
             return ResponseEntity.badRequest().build();
         }
     }
+
+
 
 }

--- a/src/main/java/com/example/eight/artwork/dto/ElementInfoDto.java
+++ b/src/main/java/com/example/eight/artwork/dto/ElementInfoDto.java
@@ -1,0 +1,18 @@
+package com.example.eight.artwork.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class ElementInfoDto {
+    private Long id;            //요소 id
+    private String name;        //요소 이름
+    private String image;       //요소 이미지
+    private boolean isSolved;   //요소 수집여부
+}

--- a/src/main/java/com/example/eight/artwork/dto/ElementResponseDto.java
+++ b/src/main/java/com/example/eight/artwork/dto/ElementResponseDto.java
@@ -17,6 +17,5 @@ import java.util.List;
 public class ElementResponseDto {
     private String relicName;       // 작품명
     private String partName;        // 작품의 부분 중 조회하고자 하는 부분명
-    private boolean part_isSolved;
     private List<ElementInfoDto> elementInfoList;   // 해당 부분의 각 요소들 정보 리스트
 }

--- a/src/main/java/com/example/eight/artwork/dto/ElementResponseDto.java
+++ b/src/main/java/com/example/eight/artwork/dto/ElementResponseDto.java
@@ -1,0 +1,22 @@
+package com.example.eight.artwork.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+/*
+특정 부분의 각 요소들 조회를 위한 DTO
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class ElementResponseDto {
+    private String relicName;       // 작품명
+    private String partName;        // 작품의 부분 중 조회하고자 하는 부분명
+    private boolean part_isSolved;
+    private List<ElementInfoDto> elementInfoList;   // 해당 부분의 각 요소들 정보 리스트
+}

--- a/src/main/java/com/example/eight/artwork/repository/ElementRepository.java
+++ b/src/main/java/com/example/eight/artwork/repository/ElementRepository.java
@@ -1,12 +1,18 @@
 package com.example.eight.artwork.repository;
 
 import com.example.eight.artwork.entity.Element;
+import com.example.eight.artwork.entity.Part;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 public interface ElementRepository extends JpaRepository<Element, Long> {
     Element findByName(String name);
+
+    // 부분에 속하는 element 리스트 조회
+    List<Element> findByPart(Part part);    
 
     @Override
     <S extends Element> S save(S entity);

--- a/src/main/java/com/example/eight/artwork/repository/SolvedElementRepository.java
+++ b/src/main/java/com/example/eight/artwork/repository/SolvedElementRepository.java
@@ -7,4 +7,5 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface SolvedElementRepository extends JpaRepository<SolvedElement, Long> {
 
+    boolean existsByUserIdAndElementId(Long userId, Long elementId);
 }

--- a/src/main/java/com/example/eight/artwork/repository/SolvedPartRepository.java
+++ b/src/main/java/com/example/eight/artwork/repository/SolvedPartRepository.java
@@ -8,4 +8,6 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface SolvedPartRepository extends JpaRepository<SolvedPart, Long> {
     int countByPartAndIsSolved(Part part, boolean isSolved);
+
+    boolean existsByUserIdAndPartId(Long userId, Long partId);
 }

--- a/src/main/java/com/example/eight/artwork/service/ArtworkService.java
+++ b/src/main/java/com/example/eight/artwork/service/ArtworkService.java
@@ -79,8 +79,8 @@ public class ArtworkService {
 
     // 작품 소제목 조회 API
     public PartsResponseDto getArtworkParts(Long relicId) {
-        // TODO: 현재 로그인된 사용자 정보 가져오는 로직 추가 필요
-        // User currentUser = getCurrentUser();
+        // 현재 로그인된 사용자 정보
+        User loginUser = userService.getAuthentication();
 
         // 작품 정보 조회
         Optional<Relic> optionalRelic = relicRepository.findById(relicId);
@@ -99,15 +99,11 @@ public class ArtworkService {
 
         // 각 부분에 대한 정보 변환
         for (Part part : parts) {
-            int solvedPartCount = solvedPartRepository.countByPartAndIsSolved(part, true);
-            boolean isPartSolvedByCurrentUser = false;  // 현재 사용자가 해당 부분을 획득했는지 여부
-
-            // TODO: 사용자가 해당 부분을 획득했는지 확인하는 로직 필요
-            // isPartSolvedByUser(part, currentUser);
+            boolean part_isSolved = solvedPartRepository.existsByUserIdAndPartId(loginUser.getId(), part.getId());
 
             PartInfoDto partInfoDto = PartInfoDto.builder()
                     .name(part.getName())  // 부분 이름
-                    .isSolved(isPartSolvedByCurrentUser)  // 현재 사용자가 해당 부분 획득 여부
+                    .isSolved(part_isSolved)  // 현재 사용자가 해당 부분 획득 여부
                     .build();
 
             partInfoDtos.add(partInfoDto);  // 변환된 부분 정보 리스트에 추가

--- a/src/main/java/com/example/eight/artwork/service/ArtworkService.java
+++ b/src/main/java/com/example/eight/artwork/service/ArtworkService.java
@@ -176,6 +176,8 @@ public class ArtworkService {
     private Part findPart(Long partId) {
         return partRepository.findById(partId)
                 .orElseThrow(() -> new EntityNotFoundException("부분을 찾을 수 없습니다."));
+    }
+
     // 작품 이미지 URI 가져오는 메서드
     public String getRelicImageUri(Long relicId) {
         // 작품 id로 작품 찾기

--- a/src/main/java/com/example/eight/artwork/service/ArtworkService.java
+++ b/src/main/java/com/example/eight/artwork/service/ArtworkService.java
@@ -144,13 +144,9 @@ public class ArtworkService {
         }
 
         // 2. 최종 DTO 생성
-        // 로그인한 유저의 part 수집 완료여부 확인
-        boolean part_isSolved = solvedPartRepository.existsByUserIdAndPartId(loginUser.getId(), part.getId());
-
         ElementResponseDto elementResponseDto = ElementResponseDto.builder()
                 .relicName(relic.getName())
                 .partName(part.getName())
-                .part_isSolved(part_isSolved)
                 .elementInfoList(elementInfoDtoList)
                 .build();
 

--- a/src/main/java/com/example/eight/user/dto/UserProfileDto.java
+++ b/src/main/java/com/example/eight/user/dto/UserProfileDto.java
@@ -1,12 +1,9 @@
 package com.example.eight.user.dto;
 
-import com.example.eight.user.Role;
 import com.example.eight.user.SocialType;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import java.time.LocalDateTime;
 
 @Getter
 @NoArgsConstructor
@@ -16,24 +13,16 @@ public class UserProfileDto {
     private String email;
     private String picture;
     private double exp;
-    private LocalDateTime createdAt;
-    private LocalDateTime updatedAt;
-    private Role role;
     private SocialType socialType;
 
 
     @Builder
-    public UserProfileDto(Long id, String name, String email, double exp, String picture,
-                          LocalDateTime createdAt, LocalDateTime updatedAt,
-                          Role role, SocialType socialType){
+    public UserProfileDto(Long id, String name, String email, double exp, String picture, SocialType socialType){
         this.id = id;
         this.name = name;
         this.email = email;
         this.picture = picture;
         this.exp = exp;
-        this.createdAt = createdAt;
-        this.updatedAt = updatedAt;
-        this.role = role;
         this.socialType = socialType;
     }
 

--- a/src/main/java/com/example/eight/user/service/UserService.java
+++ b/src/main/java/com/example/eight/user/service/UserService.java
@@ -53,9 +53,6 @@ public class UserService {
                 .email(user.getEmail())
                 .picture(user.getPicture())
                 .exp(user.getExp())
-                .createdAt(user.getCreatedAt())
-                .updatedAt(user.getUpdatedAt())
-                .role(user.getRole())
                 .socialType(user.getSocialType())
                 .build();
     }


### PR DESCRIPTION
## 이슈 번호 :round_pushpin:
#18 

## 작업 내용 :technologist:
- 부분(Part)의 각 요소(Element)들의 정보를 조회하는 API입니다. 
- 작품의 이름, 부분의 이름, 요소의 id, 이름, 이미지, 수집여부를 조회합니다. 
- 요소 수집여부 조회를 위해 SolvedElement 레포지토리에 existsByUserIdAndElementId 메소드를 추가하였습니다.
- 부분 수집여부 조회도 구현하였으나, 이 API에서 필요하지 않아 삭제하였습니다. SolvedPart 레포지토리의 existsByUserIdAndPartId는 삭제하지 않고 남겨두었습니다. 
- 응답은 ElementResponseDto를 사용하며, ElementInfoDto 리스트에 요소별 정보를 담았습니다. 

## 반영 브랜치 :rocket:
artwork/jina -> main

## To Reviewers :speech_balloon:
- API 테스트 완료했습니다. 노션 API 시트 참고해주세요.
