### PR TITLE
[FEAT] 전체 부분해설 조회 API 추가

### DIFF
--- a/src/main/java/com/example/eight/artwork/controller/ArtworkController.java
+++ b/src/main/java/com/example/eight/artwork/controller/ArtworkController.java
@@ -62,6 +62,17 @@ public class ArtworkController{
         }
     }
 
+    // 전체 부분 해설 조회 API
+    @GetMapping("parts/{relic_id}")
+    public ResponseEntity<ResponseDto> getPartDescription(@PathVariable("relic_id") Long relicId){
+        PartDescriptionResponseDto partDescriptionResponseDto = artworkService.getPartDescription(relicId);
 
+        ResponseDto responseDto = ResponseDto.builder()
+                .status("success")
+                .message("Get description for each part successful")
+                .data(partDescriptionResponseDto)
+                .build();
 
+        return ResponseEntity.ok(responseDto);
+    }
 }

--- a/src/main/java/com/example/eight/artwork/dto/PartDescriptionInfoDto.java
+++ b/src/main/java/com/example/eight/artwork/dto/PartDescriptionInfoDto.java
@@ -1,0 +1,16 @@
+package com.example.eight.artwork.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class PartDescriptionInfoDto {
+    private String name;
+    private String description;
+    private boolean isSolved;
+}

--- a/src/main/java/com/example/eight/artwork/dto/PartDescriptionResponseDto.java
+++ b/src/main/java/com/example/eight/artwork/dto/PartDescriptionResponseDto.java
@@ -1,0 +1,23 @@
+package com.example.eight.artwork.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class PartDescriptionResponseDto {
+    private Long relicId;
+    private String relicImage;  // imgUri
+    private String relicName;   // nameKr
+    private String author;      // author
+    private String nationality; //nationalityName2
+
+    private int partNum;        // 총 부분 개수
+    private List<PartDescriptionInfoDto> partDescriptionInfoList;  // 각 부분의 이름, 해설, 수집여부 리스트
+}

--- a/src/main/java/com/example/eight/artwork/service/ArtworkService.java
+++ b/src/main/java/com/example/eight/artwork/service/ArtworkService.java
@@ -91,7 +91,7 @@ public class ArtworkService {
         Relic relic = optionalRelic.get();
 
         // 작품 이미지 URI 가져오기
-        String relicImageUri = getRelicImageUri(relicId);
+        String relicImageUri = getRelicInfoByAPI(relicId, "imgUri");
 
         // 부분 정보 조회 및 변환
         List<Part> parts = partRepository.findByRelic(relic);
@@ -174,8 +174,8 @@ public class ArtworkService {
                 .orElseThrow(() -> new EntityNotFoundException("부분을 찾을 수 없습니다."));
     }
 
-    // 작품 이미지 URI 가져오는 메서드
-    public String getRelicImageUri(Long relicId) {
+    // 공공 API로 작품의 target 정보 가져오는 메소드
+    public String getRelicInfoByAPI(Long relicId, String target) {
         // 작품 id로 작품 찾기
         Optional<Relic> relicOptional = relicRepository.findById(relicId);
 
@@ -199,17 +199,17 @@ public class ArtworkService {
 
                 if (listNode != null && listNode.isArray() && listNode.size() > 0) {
                     JsonNode firstItem = listNode.get(0);
-                    String artworkImageUrl = firstItem.get("imgUri").asText();
+                    String targetInfo = firstItem.get(target).asText();
 
-                    return artworkImageUrl;
+                    return targetInfo;
                 } else {
                     // API 응답에서 이미지 URI를 찾을 수 없는 경우
-                    return "Artwork image not found in API response.";
+                    return String.format("Artwork %s not found in API response.", target);
                 }
             } catch (Exception e) {
                 // 예외 처리
                 e.printStackTrace();
-                return "Error occurred while fetching image URI: " + e.getMessage();
+                return String.format("Error occurred while fetching %s: ", target) + e.getMessage();
             }
         } else {
             // 작품이 발견되지 않았을 때


### PR DESCRIPTION
## 이슈 번호 :round_pushpin:
#20 

## 작업 내용 :technologist:
- 작품의 모든 부분해설을 조회하는 API입니다.
- 작품에 속하는 모든 부분의 이름, 해설, 수집여부를 가져옵니다.
- 작품 id, 총 부분 개수도 가져오며, 작품 Image, Name, Author, Nationality 는 공공 API에서 가져왔습니다.

## 반영 브랜치 :rocket:
artwork/jina -> main

## To Reviewers :speech_balloon:
- API 테스트 완료했습니다. 노션 API 시트 참고해주세요. (서비스 key 추가 후 테스트해야 합니다)
