### PR TITLE
부분의 해설 및 요소 조회 API 추가

### DIFF
--- a/src/main/java/com/example/eight/artwork/controller/ArtworkController.java
+++ b/src/main/java/com/example/eight/artwork/controller/ArtworkController.java
@@ -35,9 +35,9 @@ public class ArtworkController{
         return ResponseEntity.ok(responseDto);
     }
 
-    // 부분에 속하는 요소 리스트 & 수집여부 조회
-    @GetMapping("/elements")
-    public ResponseEntity<ResponseDto> getArtworkElements(@RequestParam Long relicId, @RequestParam Long partId){
+    // 부분의 요소목록 조회 (카메라 페이지)
+    @GetMapping("/elements/{relic_id}/{part_id}")
+    public ResponseEntity<ResponseDto> getArtworkElements(@PathVariable("relic_id") Long relicId, @PathVariable("part_id") Long partId){
         // 각 요소 정보 및 수집여부 응답 생성
         ElementResponseDto elementResponseDto = artworkService.getElementDetail(relicId, partId);
 

--- a/src/main/java/com/example/eight/artwork/controller/ArtworkController.java
+++ b/src/main/java/com/example/eight/artwork/controller/ArtworkController.java
@@ -75,4 +75,19 @@ public class ArtworkController{
 
         return ResponseEntity.ok(responseDto);
     }
+
+    // 부분의 해설 및 요소정보 조회 API
+    @GetMapping("/parts/details/{relic_id}/{part_id}")
+    public ResponseEntity<ResponseDto> getPartDescriptionAndElementInfo(@PathVariable("relic_id") Long relicId, @PathVariable("part_id") Long partId){
+
+        PartDescriptionAndElementResponseDto partDescriptionAndElementResponseDto = artworkService.getPartDescriptionAndElement(relicId, partId);
+
+        ResponseDto responseDto = ResponseDto.builder()
+                .status("success")
+                .message("Get a part description and element list successful")
+                .data(partDescriptionAndElementResponseDto)
+                .build();
+
+        return ResponseEntity.ok(responseDto);
+    }
 }

--- a/src/main/java/com/example/eight/artwork/dto/ElementInfoAndPointDto.java
+++ b/src/main/java/com/example/eight/artwork/dto/ElementInfoAndPointDto.java
@@ -1,0 +1,16 @@
+package com.example.eight.artwork.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class ElementInfoAndPointDto {
+    private Long id;
+    private String point;
+    private boolean isSolved;
+}

--- a/src/main/java/com/example/eight/artwork/dto/PartDescriptionAndElementResponseDto.java
+++ b/src/main/java/com/example/eight/artwork/dto/PartDescriptionAndElementResponseDto.java
@@ -1,0 +1,30 @@
+package com.example.eight.artwork.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+/*
+특정 부분의 해설과 요소들의 정보 조회하는 API
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class PartDescriptionAndElementResponseDto {
+    // 작품 정보
+    private Long relicId;
+    private String relicImage;  // 공공 API - imgUri
+    private String relicName;   // 공공 API - nameKr
+    //부분 정보 및 해설
+    private String partName;
+    private String partDescription;
+    private boolean part_isSolved;
+    // 요소 정보
+    private int elementNum;
+    private int elementSolvedNum;
+    private List<ElementInfoAndPointDto> elementList;  // 요소들의 id, point, 수집여부 리스트
+}

--- a/src/main/java/com/example/eight/artwork/entity/Relic.java
+++ b/src/main/java/com/example/eight/artwork/entity/Relic.java
@@ -23,10 +23,6 @@ public class Relic {
     private String apiId;
 
     @NotNull
-    @Column(name = "name", length = 30)
-    private String name;
-
-    @NotNull
     @Column(name = "image", length = 300)
     private String image;
 
@@ -45,10 +41,9 @@ public class Relic {
     private List<Part> parts = new ArrayList<>();
 
     @Builder
-    public Relic(String apiId, @NotNull String name, @NotNull String image, @NotNull String badgeImage,
+    public Relic(String apiId, @NotNull String image, @NotNull String badgeImage,
                  String location, @NotNull Integer partNum, List<Part> parts) {
         this.apiId = apiId;
-        this.name = name;
         this.image = image;
         this.badgeImage = badgeImage;
         this.location = location;

--- a/src/main/java/com/example/eight/artwork/repository/RelicRepository.java
+++ b/src/main/java/com/example/eight/artwork/repository/RelicRepository.java
@@ -9,7 +9,6 @@ import java.util.List;
 
 @Repository
 public interface RelicRepository extends JpaRepository<Relic, Long> {
-    Relic findByName(String name);
 
     Optional<Relic> findByApiId(String apiId);
 

--- a/src/main/java/com/example/eight/artwork/service/ArtworkService.java
+++ b/src/main/java/com/example/eight/artwork/service/ArtworkService.java
@@ -219,6 +219,21 @@ public class ArtworkService {
         return partDescriptionResponseDto;
     }
 
+
+
+    // 유저가 수집완료한 요소 수 가져오는 메소드
+    private int getSolvedElementNum(Long userId, Long partId) {
+        // 부분 찾기
+        Part part = findPart(partId);
+        // 부분의 모든 요소 list
+        List<Element> elementList = elementRepository.findByPart(part);
+
+        return (int) elementList.stream()
+                // 유저의 각 요소 수집 완료여부
+                .filter(element -> solvedElementRepository.existsByUserIdAndElementId(userId, element.getId()))
+                .count();   // true인 것만 카운트
+    }
+
     // 공공 API로 작품의 target 정보 가져오는 메소드
     public String getRelicInfoByAPI(Long relicId, String target) {
         // 작품 id로 작품 찾기

--- a/src/main/java/com/example/eight/artwork/service/ArtworkService.java
+++ b/src/main/java/com/example/eight/artwork/service/ArtworkService.java
@@ -87,8 +87,9 @@ public class ArtworkService {
 
         Relic relic = optionalRelic.get();
 
-        // 작품 이미지 URI 가져오기
+        // 공공 API에서 작품 이미지 URI, 작품 이름 가져오기
         String relicImageUri = getRelicInfoByAPI(relicId, "imgUri");
+        String relicName = getRelicInfoByAPI(relicId, "nameKr");
 
         // 부분 정보 조회 및 변환
         List<Part> parts = partRepository.findByRelic(relic);
@@ -110,7 +111,7 @@ public class ArtworkService {
         int totalSolvedPartCount = (int) partInfoDtos.stream().filter(PartInfoDto::isSolved).count();
 
         PartsResponseDto responseDto = PartsResponseDto.builder()
-                .relicName(relic.getName())
+                .relicName(relicName)
                 .relicImage(relicImageUri)  // 작품 이미지 URI 설정
                 .relicBadgeImage(relic.getBadgeImage())
                 .partInfos(partInfoDtos)
@@ -121,7 +122,7 @@ public class ArtworkService {
         return responseDto;  // 최종 응답 객체
     }
 
-    // part의 각 element 정보와 수집여부 조회 API
+    // 부분의 요소 조회 API (카메라 페이지)
     public ElementResponseDto getElementDetail(Long relicId, Long partId) {
         // 현재 로그인한 유저
         User loginUser = userService.getAuthentication();
@@ -149,9 +150,12 @@ public class ArtworkService {
             elementInfoDtoList.add(elementInfoDto);
         }
 
+        // 공공 API에서 작품 이름 가져오기
+        String relicName = getRelicInfoByAPI(relicId, "nameKr");
+
         // 2. 최종 DTO 생성
         ElementResponseDto elementResponseDto = ElementResponseDto.builder()
-                .relicName(relic.getName())
+                .relicName(relicName)
                 .partName(part.getName())
                 .elementInfoList(elementInfoDtoList)
                 .build();


### PR DESCRIPTION
## 이슈 번호 :round_pushpin:
#25 

## 작업 내용 :technologist:
- 부분에 대한 해설 및 요소목록을 조회하는 API입니다. 
- 요소 목록에는 각 요소의 id, 수집여부, point 값이 들어있습니다. 
- 작품의 기본정보, 부분의 해설과 수집여부, 수집한 요소 개수도 가져옵니다.

## 반영 브랜치 :rocket:
artwork/jina -> main

## To Reviewers :speech_balloon:
- API 테스트 완료했습니다. 노션 API 시트 참고해주세요. 
