### PR TITLE
[FEAT] 도감 오버뷰 조회 API 추가

### DIFF
--- a/src/main/java/com/example/eight/artwork/repository/SolvedRelicRepository.java
+++ b/src/main/java/com/example/eight/artwork/repository/SolvedRelicRepository.java
@@ -8,4 +8,6 @@ import org.springframework.stereotype.Repository;
 public interface SolvedRelicRepository extends JpaRepository<SolvedRelic, Long> {
 
     SolvedRelic findByUserIdAndRelicId(Long userId, Long relicId);
+
+    boolean existsByUserIdAndRelicId(Long userId, Long relicId);
 }

--- a/src/main/java/com/example/eight/collection/controller/CollectionController.java
+++ b/src/main/java/com/example/eight/collection/controller/CollectionController.java
@@ -1,0 +1,13 @@
+package com.example.eight.collection.controller;
+
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Controller
+@AllArgsConstructor
+@RequestMapping("/app/collection")
+public class CollectionController {
+
+    
+}

--- a/src/main/java/com/example/eight/collection/controller/CollectionController.java
+++ b/src/main/java/com/example/eight/collection/controller/CollectionController.java
@@ -1,7 +1,12 @@
 package com.example.eight.collection.controller;
 
+import com.example.eight.collection.dto.OverviewResponseDto;
+import com.example.eight.collection.service.CollectionService;
+import com.example.eight.global.ResponseDto;
 import lombok.AllArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 @Controller
@@ -10,4 +15,21 @@ import org.springframework.web.bind.annotation.RequestMapping;
 public class CollectionController {
 
     
+    private final CollectionService collectionService;
+
+    // 수집 오버뷰 조회 API
+    @GetMapping("/overview")
+    public ResponseEntity<ResponseDto> getCollectionOverview(){
+        OverviewResponseDto overviewResponseDto = collectionService.getOverview();
+
+        ResponseDto responseDto = ResponseDto.builder()
+                .status("success")
+                .message("Get Overview successful")
+                .data(overviewResponseDto)
+                .build();
+
+        return ResponseEntity.ok(responseDto);
+
+    }
+
 }

--- a/src/main/java/com/example/eight/collection/dto/OverviewDto.java
+++ b/src/main/java/com/example/eight/collection/dto/OverviewDto.java
@@ -1,0 +1,15 @@
+package com.example.eight.collection.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class OverviewDto {
+    private Long relicId;
+    private String badgeImage;
+}

--- a/src/main/java/com/example/eight/collection/dto/OverviewResponseDto.java
+++ b/src/main/java/com/example/eight/collection/dto/OverviewResponseDto.java
@@ -1,0 +1,19 @@
+package com.example.eight.collection.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class OverviewResponseDto {
+    private String userImage;
+    private double userExp;
+    private int solvedRelicNum;
+    private List<OverviewDto> badgeList;    // 수집한 작품의 id와 뱃지 이미지 담은 List
+}

--- a/src/main/java/com/example/eight/collection/service/CollectionService.java
+++ b/src/main/java/com/example/eight/collection/service/CollectionService.java
@@ -1,0 +1,12 @@
+package com.example.eight.collection.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class CollectionService {
+
+}

--- a/src/main/java/com/example/eight/collection/service/CollectionService.java
+++ b/src/main/java/com/example/eight/collection/service/CollectionService.java
@@ -1,12 +1,91 @@
 package com.example.eight.collection.service;
 
+import com.example.eight.artwork.entity.Relic;
+import com.example.eight.artwork.repository.RelicRepository;
+import com.example.eight.artwork.repository.SolvedRelicRepository;
+import com.example.eight.collection.dto.OverviewDto;
+import com.example.eight.collection.dto.OverviewResponseDto;
+import com.example.eight.user.entity.User;
+import com.example.eight.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Service
 @Transactional
 @RequiredArgsConstructor
 public class CollectionService {
+
+    private final UserService userService;
+    private final RelicRepository relicRepository;
+    private final SolvedRelicRepository solvedRelicRepository;
+
+    // 수집 오버뷰 조회 API
+    public OverviewResponseDto getOverview(){
+        // 현재 로그인한 유저 정보
+        User user = userService.getAuthentication();
+
+        // 수집한 작품 리스트 가져오기
+        List<Relic> collectedRelicList = getCollectedRelicList(user.getId());
+
+        // 수집한 작품의 id와 badge 이미지 리스트 생성
+        List<OverviewDto> overviewDtoList = new ArrayList<>();
+        for(Relic relic: collectedRelicList){
+            OverviewDto overviewDto = OverviewDto.builder()
+                    .relicId(relic.getId())
+                    .badgeImage(relic.getBadgeImage())
+                    .build();
+
+            overviewDtoList.add(overviewDto); // dto 리스트에 추가
+        }
+
+        // 오버뷰 응답 생성
+        int solvedRelicNum = getCollectionNum(user.getId());
+        OverviewResponseDto overviewResponseDto = OverviewResponseDto.builder()
+                .userImage(user.getPicture())
+                .userExp(user.getExp())
+                .solvedRelicNum(solvedRelicNum)
+                .badgeList(overviewDtoList)
+                .build();
+
+        return overviewResponseDto;
+    }
+
+    // 수집한 작품 리스트 반환하는 메소드
+    public List<Relic> getCollectedRelicList(Long userId){
+        List<Relic> collectionList = new ArrayList<Relic>();      // 도감
+
+        // 해당 유저의 수집한 relic 리스트 가져오기
+        List<Relic> relicList = relicRepository.findAll();
+        for(Relic relic: relicList) {
+            boolean isSolved = solvedRelicRepository.existsByUserIdAndRelicId(userId, relic.getId());
+
+            if(isSolved == false){
+                continue;
+            }
+            collectionList.add(relic);
+        }
+
+        return collectionList;
+    }
+
+    // 유저가 수집완료한 작품 수 가져오는 메소드
+    private int getCollectionNum(Long userId) {
+        int count = 0;
+        List<Relic> relicList = relicRepository.findAll();  // 모든 작품의 list
+
+        // 수집한 개수 카운트
+        for(Relic relic: relicList){
+            boolean isSolved = solvedRelicRepository.existsByUserIdAndRelicId(userId, relic.getId());
+            if(isSolved){
+                count++;
+            }
+        }
+
+        return count;
+    }
 
 }


### PR DESCRIPTION
## 이슈 번호 :round_pushpin:
#55 

## 작업 내용 :technologist:
- 유저가 수집한 작품의 overview를 조회하는 API입니다.
- collection 패키지와 브랜치를 새로 만들어 작업했습니다.

## 반영 브랜치 :rocket:
collection/jina -> main

## To Reviewers :speech_balloon:
- API 시트 참고해주세요!
