### PR TITLE
[feature] 챌린지 조회 API 추가

### DIFF
--- a/src/main/java/com/example/eight/artwork/service/ArtworkService.java
+++ b/src/main/java/com/example/eight/artwork/service/ArtworkService.java
@@ -372,7 +372,7 @@ public class ArtworkService {
     }
 
     // 유저가 수집완료한 부분 수 가져오는 메소드
-    private int getSolvedPartNum(Long userId, Long relicId) {
+    public int getSolvedPartNum(Long userId, Long relicId) {
         // 작품 찾기
         Relic relic = findRelic(relicId);
         // 작품의 모든 부분 list

--- a/src/main/java/com/example/eight/collection/controller/CollectionController.java
+++ b/src/main/java/com/example/eight/collection/controller/CollectionController.java
@@ -1,5 +1,6 @@
 package com.example.eight.collection.controller;
 
+import com.example.eight.collection.dto.ChallengeResponseDto;
 import com.example.eight.collection.dto.CollectionResponseDto;
 import com.example.eight.collection.dto.OverviewResponseDto;
 import com.example.eight.collection.service.CollectionService;
@@ -45,6 +46,14 @@ public class CollectionController {
                 .build();
 
         return ResponseEntity.ok(responseDto);
+    }
+
+    // 도감 도전과제 조회 API
+    @GetMapping("/challenge")
+    public ResponseEntity<ChallengeResponseDto> getChallenge(){
+        ChallengeResponseDto challengeResponseDto = collectionService.getChallengeList();
+
+        return ResponseEntity.ok(challengeResponseDto);
     }
 
 }

--- a/src/main/java/com/example/eight/collection/dto/ChallengeDto.java
+++ b/src/main/java/com/example/eight/collection/dto/ChallengeDto.java
@@ -1,0 +1,22 @@
+package com.example.eight.collection.dto;
+
+import com.example.eight.artwork.dto.PartInfoDto;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class ChallengeDto {
+    private Long relicId;
+    private String relicName;
+    private String badgeImage;
+    private int partNum;
+    private int solvedPartNum;
+    private List<PartInfoDto> partList;
+}

--- a/src/main/java/com/example/eight/collection/dto/ChallengeResponseDto.java
+++ b/src/main/java/com/example/eight/collection/dto/ChallengeResponseDto.java
@@ -1,0 +1,16 @@
+package com.example.eight.collection.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class ChallengeResponseDto {
+    List<ChallengeDto> challengeList;
+}


### PR DESCRIPTION
## 이슈 번호 :round_pushpin:
#67 

## 작업 내용 :technologist:
- 도감 페이지에서 챌린지를 조회하는 API입니다.
- 전체 작품에 대한 챌린지를 가져옵니다. 작품의 부분도 전부 가져온 후 유저의 수집여부를 표시합니다.

## 반영 브랜치 :rocket:
collection/jina -> main

## To Reviewers :speech_balloon:
- 노션 API 시트 참고해주세요!
