### PR TITLE
[FEAT] 로그아웃 API 추가 및 Redis 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,7 @@ dependencies {
 	implementation('com.auth0:java-jwt:4.4.0')		//jwt 오픈소스 라이브러리 java-jwt
 	implementation group: 'org.apache.commons', name: 'commons-text', version: '1.9' // 작품명 유사도 검증 라이브러리
 	implementation 'io.github.flashvayne:chatgpt-spring-boot-starter:1.0.4' //  gpt 라이브러리
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'	// Redis
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/eight/global/config/RedisConfig.java
+++ b/src/main/java/com/example/eight/global/config/RedisConfig.java
@@ -1,0 +1,42 @@
+package com.example.eight.global.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@RequiredArgsConstructor
+@Configuration
+@EnableRedisRepositories  // Redis Repository 활성화
+public class RedisConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String redisHost;
+
+    @Value("${spring.data.redis.port}")
+    private int redisPort;
+
+    // Redis 연결을 위한 RedisConnectionFactory 생성 (Redis 클라이언트로 Lettuce 사용)
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory(){
+        return new LettuceConnectionFactory(redisHost, redisPort);  // .properties 파일에서 설정한 host, port 가져와 연동
+    }
+
+    // Redis에 데이터 저장, 검색을 위한 RedisTemplate 설정
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate() {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+
+        // StringRedisSerializer로 직렬화 방법 설정
+        redisTemplate.setKeySerializer(new StringRedisSerializer());    // 문자열 key 저장
+        redisTemplate.setValueSerializer(new StringRedisSerializer());  // 문자열 value 저장
+
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        return redisTemplate;
+    }
+}

--- a/src/main/java/com/example/eight/global/jwt/controller/JwtController.java
+++ b/src/main/java/com/example/eight/global/jwt/controller/JwtController.java
@@ -1,7 +1,7 @@
 package com.example.eight.global.jwt.controller;
 
-import com.example.eight.global.jwt.service.JwtService;
 import com.example.eight.global.ResponseDto;
+import com.example.eight.global.jwt.service.JwtService;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -9,6 +9,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.io.IOException;
@@ -27,5 +28,15 @@ public class JwtController {
     public ResponseEntity<ResponseDto> validateRefreshToken(@RequestBody HashMap<String, String> bodyJson, HttpServletResponse response) throws IOException {
 
         return jwtService.validateRefreshToken(bodyJson, response);
+    }
+
+    @Transactional
+    @PostMapping("/app/auth/logout")
+    public ResponseEntity<ResponseDto> logout(@RequestHeader("Authorization") String accessToken){
+        if(accessToken != null && accessToken.startsWith("Bearer ")){
+            accessToken = accessToken.substring(7); // 헤더에서 Bearer 삭제
+        }
+
+        return jwtService.logout(accessToken);
     }
 }

--- a/src/main/java/com/example/eight/global/jwt/service/JwtService.java
+++ b/src/main/java/com/example/eight/global/jwt/service/JwtService.java
@@ -204,4 +204,18 @@ public class JwtService {
         return ResponseEntity.status(status).body(responseDto);
     }
 
+
+    // AccessToken에서 expiresTime 추출하는 메소드
+    public Optional<Long> getExpiresTime(String accessToken) {
+        try {
+            DecodedJWT decodedJWT = (JWT.require(Algorithm.HMAC512(secretKey)).build().verify(accessToken));
+            // 만료시간 리턴 (현재시간 차감 후 남은 만료시간)
+            Long expiresTime = decodedJWT.getExpiresAt().getTime();
+            Long now = new Date().getTime();    // 현재 시간
+            return Optional.ofNullable(expiresTime - now);  // 기본 만료시간은 1시간 (3600초)
+        } catch (Exception e) {
+            log.error("expiresTime 추출 오류: {}", e);
+            return Optional.empty();
+        }
+    }
 }

--- a/src/main/java/com/example/eight/global/jwt/service/JwtService.java
+++ b/src/main/java/com/example/eight/global/jwt/service/JwtService.java
@@ -14,6 +14,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
@@ -23,6 +24,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 
 @Setter         //테스트코드에서 사용하기 위해 추가
 @Service
@@ -51,6 +53,7 @@ public class JwtService {
     @Value("${jwt.refresh.header}")
     private String refreshHeader;   // Authorization-refresh
 
+    private final RedisTemplate redisTemplate;
 
     /*
      AccessToken 생성
@@ -204,6 +207,32 @@ public class JwtService {
         return ResponseEntity.status(status).body(responseDto);
     }
 
+    // 로그아웃 메소드
+    public ResponseEntity<ResponseDto> logout(String accessToken){
+        try {
+            // accessToken의 유효시간 추출해서, 해당 시간동안 Redis에 블랙리스트로 저장
+            Long expiration = getExpiresTime(accessToken).get();
+            redisTemplate.opsForValue().set(accessToken, "logout", expiration, TimeUnit.MILLISECONDS);
+
+            // 200 응답
+            ResponseDto responseDto = ResponseDto.builder()
+                    .status("success")
+                    .message("Logout successful")
+                    .data(null)
+                    .build();
+
+            return ResponseEntity.ok(responseDto);
+        }
+        // accessToken 만료된 경우 401 응답
+        catch (TokenExpiredException e) {
+            return createResponseEntity(HttpStatus.UNAUTHORIZED, "Expired access Token", null);
+        }
+        // 그 외 401 응답
+        catch (Exception e) {
+            log.error(e.getMessage());
+            return createResponseEntity(HttpStatus.UNAUTHORIZED, "Access Token is Invalid", null);
+        }
+    }
 
     // AccessToken에서 expiresTime 추출하는 메소드
     public Optional<Long> getExpiresTime(String accessToken) {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -23,7 +23,7 @@ jwt.refresh.expiration=1209600
 jwt.refresh.header=Authorization-refresh
 
 # Redis Configuration
-spring.data.redis.host=localhost
+spring.data.redis.host=${REDIS_HOST}
 spring.data.redis.port=6379
 spring.data.redis.password=root1234
 


### PR DESCRIPTION
## 이슈 번호 :round_pushpin:
#74

## 작업 내용 :technologist:
- 로그아웃 api 요청시, 해당 access token을 Redis 메모리에 블랙리스트로 저장하는 API입니다. (access token 만료시간 후 자동으로 삭제됩니다)
- AWS ElasticCache Redis 생성했습니다. 
- jwt 토큰 필터에 Redis 블랙리스트에 저장되어있는지 여부 확인하는 로직 추가했습니다. 

## 반영 브랜치 :rocket:
logout/jina -> main

## To Reviewers :speech_balloon:
- 노션 API 시트와 환경변수 시트 확인해주세요!
