### PR TITLE
[UPDATE] GPT 해설 제공 API 응답 객체 수정

### DIFF
--- a/src/main/java/com/example/eight/gpt/service/ChatService.java
+++ b/src/main/java/com/example/eight/gpt/service/ChatService.java
@@ -62,7 +62,7 @@ public class ChatService {
     public GptResponseDto generateDescription(String nameKr, String relicDescription) {
 
         String prompt = "작품 전체해설에서 " + nameKr + " 정보 찾아줘."
-                + "전체해설:\n" + relicDescription;
+                + "\n전체해설:" + relicDescription;
         String elementDescription = chatgptService.sendMessage(prompt);
 
         // 작품 정보 불러오기
@@ -70,7 +70,7 @@ public class ChatService {
         String elementImage = element.getImage();
         Relic relic = element.getPart().getRelic();
         Long relicId = relic.getId();
-        String relicName = relic.getNameEn();
+        String relicName = artworkService.getRelicInfoByAPI(relicId,"nameKr");
 
         // 응답 객체 반환
         return new GptResponseDto(relicId, relicName, elementImage, nameKr, elementDescription);


### PR DESCRIPTION
## 이슈 번호 :round_pushpin:
#77 

## 작업 내용 :technologist:
AS-IS: GPT 해설 제공 API 응답에 작품 영문명 반환, 이미지 반환 X
TO-BE: 작품 국문명으로 반환, 이미지 반환

## 반영 브랜치 :rocket:
gpt/yeni -> main

## To Reviewers :speech_balloon:
- 관련 파일은 노션 참고해주세요!

