### PR TITLE
[UPDATE] GPT 해설 제공 API context 변경

### DIFF
--- a/src/main/java/com/example/eight/gpt/service/ChatService.java
+++ b/src/main/java/com/example/eight/gpt/service/ChatService.java
@@ -46,7 +46,7 @@ public class ChatService {
         Long relicId = relic.getId();
 
         // 작품의 전체 해설 가져오기
-        return artworkService.getRelicDescription(relicId);
+        return element.getPart().getTextDescription();
     }
 
     // STEP3: 요소 영문명으로 국문명 찾기
@@ -61,8 +61,8 @@ public class ChatService {
     // STEP4: 요소 이름과 작품 해설을 사용하여 GPT에 정보 요청 + 작품 정보 찾아와 응답 객체 만들기
     public GptResponseDto generateDescription(String nameKr, String relicDescription) {
 
-        String prompt = "작품 전체해설에서 " + nameKr + " 정보 찾아줘."
-                + "\n전체해설:" + relicDescription;
+        String prompt = "작품해설에서 '" + nameKr + "' 정보 찾아줘."
+                + "\n작품해설:" + relicDescription;
         String elementDescription = chatgptService.sendMessage(prompt);
 
         // 작품 정보 불러오기

--- a/src/main/resources/application-oauth.properties
+++ b/src/main/resources/application-oauth.properties
@@ -8,5 +8,5 @@ SERVIC_KEY.value=${SERVICE_KEY}
 
 # OpenAI Service Key configuration
 chatgpt.api-key=${GPT_KEY}
-chatgpt.max-tokens: 1920
+chatgpt.max-tokens: 2000
 chatgpt.model: gpt-3.5-turbo-instruct


### PR DESCRIPTION
## 이슈 번호 :round_pushpin:
#79 

## 작업 내용 :technologist:
GPT 해설 제공 API context 변경
전체해설 대신 부분 해설로 context로 제공

## 반영 브랜치 :rocket:
gpt/yeni->main

## To Reviewers :speech_balloon:
 관련 파일은 노션 참고해주세요!

